### PR TITLE
Comment out iso_to_av96 and update cython version

### DIFF
--- a/make/base-jail.sh
+++ b/make/base-jail.sh
@@ -41,9 +41,10 @@ apt-get -y --force-yes install \
    pkg-config libgl1-mesa-dev libgles2-mesa-dev \
    libgstreamer1.0-dev \
    gstreamer1.0-plugins-{bad,base,good,ugly} \
-   gstreamer1.0-{omx,alsa} python-dev cython
+   gstreamer1.0-{omx,alsa} python-dev
 apt-get -y --force-yes install libmtdev1
 
+pip install -I Cython==0.23
 pip install git+https://github.com/kivy/kivy.git@master
 
 apt-get clean

--- a/src/camera.py
+++ b/src/camera.py
@@ -259,7 +259,7 @@ class Camera:
 
   def makeOptions(self):
     options = {}
-    options['svm'] = chdkptp.util.iso_to_sv96(100)
+    options['svm'] = chdkptp.util.iso_to_av96(100)
     options['tv'] = chdkptp.util.shutter_to_tv96(self.calculate_shutter())
     options['nd'] = 2
     options['fformat'] = 1

--- a/src/camera.py
+++ b/src/camera.py
@@ -259,7 +259,8 @@ class Camera:
 
   def makeOptions(self):
     options = {}
-    options['svm'] = chdkptp.util.iso_to_av96(100)
+    # TODO: the Lua API for this function changed. this method no longer works with chdkptp.py HEAD 
+    #options['svm'] = chdkptp.util.iso_to_av96(100)
     options['tv'] = chdkptp.util.shutter_to_tv96(self.calculate_shutter())
     options['nd'] = 2
     options['fformat'] = 1


### PR DESCRIPTION
Two build issues

1.  The Kivy of today depends on a newer version of cython. Update it.
2. The chdkptp.py upstream HEAD has a different API than the one included in the Rpi image

The first exception is the method name [iso_to_sv96 has been changed to iso_to_av96](https://github.com/jbaiter/chdkptp.py/blob/0158a3c375d908ba42c62db697ba328f6a950c33/chdkptp/util.py#L6). I updated the method call and expected it to just work. Then I got a new exception when calling the updated method.

```
>>> chdkptp.util.iso_to_av96(100)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/lib/python2.7/dist-packages/chdkptp/util.py", line 7, in iso_to_av96
    return global_lua.globals.exposure.iso_to_av96(iso)
TypeError: 'NoneType' object is not callable
```

I searched through the pi-scan codebase for the string [svm](https://github.com/Tenrec-Builders/pi-scan/search?utf8=%E2%9C%93&q=svm&type=) and it doesn't appear anywhere except in this option dict, which I think is trying to set the ISO to a value of 100. I commented this out and things are working as expected.

I would like to bring the API up to date but it's not directly related to my project. If it's cool with you the comment seems to fix the functionality on my end.