### PR TITLE
fix on_key_up signature to have correct number of params

### DIFF
--- a/src/camera_chdk.py
+++ b/src/camera_chdk.py
@@ -58,6 +58,8 @@ def search():
           result.append(info)
   except LuaError as e:
     errorlog.write('Failed to search: LuaError: ' + str(e.args) + '\nTraceback: ' + traceback.format_exc())
+  except chdkptp.PTPError as e:
+    errorlog.write('Failed to search: PTPError: ' + str(e.args) + '\n' + traceback.format_exc() + '\nPTP Traceback:\n' + e.traceback)
   except Exception as e:
     errorlog.write('Failed to search: ' + str(e.args) + '\n' + traceback.format_exc())
   return result
@@ -105,6 +107,8 @@ class Camera:
         else:
           self.message = 'Lost connection before prepare capture'
           self.log('Failed while preparing: ' + self.message)
+      except chdkptp.PTPError as e:
+        self.log('Failed while preparing: PTPError: ' + str(e.args) + '\n' + traceback.format_exc() + '\nPTP Traceback:\n' + e.traceback)
       except Exception as e:
         self.log('Failed while preparing: ' + str(e.args) + '\n' + traceback.format_exc())
     return success
@@ -167,6 +171,8 @@ class Camera:
       else:
         self.message = 'Lost connection before refocus'
         self.log('Failed to refocus: ' + self.message)
+    except chdkptp.PTPError as e:
+      self.log('Failed to refocus: PTPError: ' + str(e.args) + '\n' + traceback.format_exc() + '\nPTP Traceback:\n' + e.traceback)
     except Exception as e:
       self.log('Failed to refocus: ' + str(e.args) + '\n' + traceback.format_exc())
     return success
@@ -181,8 +187,10 @@ class Camera:
       else:
         self.message = 'Lost connection before unlock focus'
         self.log('Failed to unlock focus: ' + self.message)
+    except chdkptp.PTPError as e:
+      self.log('Failed to unlock focus: PTPError: ' + str(e.args) + '\n' + traceback.format_exc() + '\nPTP Traceback:\n' + e.traceback)
     except Exception as e:
-      self.log('Failed to refocus: ' + str(e.args) + '\n' + traceback.format_exc())
+      self.log('Failed to unlock focus: ' + str(e.args) + '\n' + traceback.format_exc())
     return success
     
   def connect(self):
@@ -192,6 +200,8 @@ class Camera:
       if not self.device.is_connected:
         self.device.reconnect()
       success = True
+    except chdkptp.PTPError as e:
+      self.log('Failed to connect: PTPError: ' + str(e.args) + '\n' + traceback.format_exc() + '\nPTP Traceback:\n' + e.traceback)
     except Exception as e:
       self.log('Failed to connect: ' + str(e.args) + '\n' + traceback.format_exc())
     return success
@@ -256,6 +266,8 @@ class Camera:
         self.message = 'Tried to capture before preparing camera'
       else:
         self.message = 'Lost connection before capture'
+    except chdkptp.PTPError as e:
+      self.log('Failed to capture: PTPError: ' + str(e.args) + '\n' + traceback.format_exc() + '\nPTP Traceback:\n' + e.traceback)
     except Exception as e:
       self.log('Failed to capture: ' + str(e.args) + '\n' + traceback.format_exc())
     return result
@@ -356,6 +368,8 @@ class Camera:
     try:
       if self.is_connected():
         self.device.lua_execute('sleep(50); play_sound(6)', do_return=False)
+    except chdkptp.PTPError as e:
+      self.log('Failed to beep: PTPError: ' + str(e.args) + '\n' + traceback.format_exc() + '\nPTP Traceback:\n' + e.traceback)
     except Exception as e:
       self.log('Failed to beep: ' + str(e) + ' ' + str(e.args) + '\n' + traceback.format_exc())
 
@@ -366,6 +380,8 @@ class Camera:
       if self.is_connected():
         self.device.lua_execute('sleep(50); post_levent_to_ui("PressPowerButton")',
                                 do_return=False)
+    except chdkptp.PTPError as e:
+      self.log('Failed to power off: PTPError: ' + str(e.args) + '\n' + traceback.format_exc() + '\nPTP Traceback:\n' + e.traceback)
     except Exception as e:
       self.log('Failed to power off: ' + str(e) + ' ' + str(e.args) + '\n' + traceback.format_exc())
 

--- a/src/main.py
+++ b/src/main.py
@@ -1361,7 +1361,7 @@ class ScanApp(App):
         handleCrash(e)
     return True
 
-  def on_key_up(self, window, scancode, codepoint, key, other):
+  def on_key_up(self, window, scancode, codepoint):
     self.handlingKey = False
 
 if __name__ == '__main__':

--- a/src/main.py
+++ b/src/main.py
@@ -1216,12 +1216,11 @@ class DebugScreen(Screen):
 
   def on_pre_enter(self):
     try:
-      self.oddMessage.text = ''
-      self.evenMessage.text = ''
-      self.oddStatus.text = 'Searching...'
-      self.evenStatus.text = 'Searching...'
       even.camera.beepFail()
       odd.camera.beepFail()
+      (oddFound, evenFound, tooManyFound) = checkCameras()
+      self.updateSide(oddFound, odd, self.oddStatus, self.oddLog, self.oddMessage)
+      self.updateSide(evenFound, even, self.evenStatus, self.evenLog, self.evenMessage)
     except Exception as e:
       handleCrash(e)
 


### PR DESCRIPTION
I was getting an error while running on macos when pressing any keys:

TypeError: +on_key_up() takes exactly 6 arguments (4 given)

I don't understand why the signature doesn't match https://kivy.org/docs/api-kivy.core.window.html?highlight=request_keyboard#kivy.core.window.WindowBase.request_keyboard, but this is the correct number of arguments to fix that error, and I think they are labeled correctly...